### PR TITLE
Add linting script and dependencies

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -17,6 +17,6 @@
     "no-trailing-spaces": 1,
     "no-underscore-dangle": 0,
     "quotes": [1, "single"],
-    "space-before-function-parentheses": [1, "always"]
+    "space-before-function-paren": [1, "always"]
   }
 }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "build": "iojs build.js",
     "gulp": "iojs node_modules/gulp/bin/gulp.js",
-    "serve": "iojs build.js serve"
+    "serve": "iojs build.js serve",
+    "lint": "eslint scripts build.js plugins"
   },
   "repository": {
     "type": "git",
@@ -36,5 +37,9 @@
     "octonode": "^0.7.1",
     "require-dir": "^0.3.0",
     "st": "^0.5.5"
+  },
+  "devDependencies": {
+    "babel-eslint": "^4.0.10",
+    "eslint": "^1.1.0"
   }
 }

--- a/plugins/map-handlebars-partials.js
+++ b/plugins/map-handlebars-partials.js
@@ -7,7 +7,7 @@ const Path = require('path');
 /**
  * Map handlebars partials as { $partialName: $partialPath/$partialName }
  */
-module.exports = function mapHandlebarsPartials(metalsmith, layoutPath, partialPath) {
+module.exports = function mapHandlebarsPartials (metalsmith, layoutPath, partialPath) {
 
     const fullPath = metalsmith.path(layoutPath, partialPath);
     let partials = {};

--- a/scripts/tasks/build.js
+++ b/scripts/tasks/build.js
@@ -1,6 +1,6 @@
 var gulp = require('gulp');
 
-gulp.task('build', function(cb){
-  console.log("Placeholder. Nothing to do.");
+gulp.task('build', function (cb) {
+  console.log('Placeholder. Nothing to do.');
   cb();
 });

--- a/scripts/tasks/download.js
+++ b/scripts/tasks/download.js
@@ -1,4 +1,4 @@
-"use strict";
+'use strict';
 
 var github = require('octonode');
 var client = github.client();
@@ -18,7 +18,7 @@ var crypto = require('crypto');
  * - [ ] prepend predictable markdown metadata on download
  */
 
-function checkOrFetchFile(file) {
+function checkOrFetchFile (file) {
   let name = file.name;
   let downloadUrl = file.download_url;
   let sha = file.sha;
@@ -32,11 +32,11 @@ function checkOrFetchFile(file) {
   console.log(`Weekly Update ${name} does not exist. Downloading.`);
 
   var file = fs.createWriteStream(localPath);
-  var request = https.get(downloadUrl, function(response) {
+  var request = https.get(downloadUrl, function (response) {
     response.pipe(file);
   });
 }
 
-evRepo.contents('weekly-updates', function(err, files) {
+evRepo.contents('weekly-updates', function (err, files) {
   files.forEach(checkOrFetchFile);
 })


### PR DESCRIPTION
Hi!

I noticed there was an `.eslintrc` here, but couldnt see any linting script defined?

This enables eslinting of source JS files by running:

```bash
$ npm run lint
```

Also fixed some minor linting issues.