### PR TITLE
Switchable banner/notification/alert about important security upgrades

### DIFF
--- a/build.js
+++ b/build.js
@@ -51,10 +51,13 @@ function traverse (obj, str) {
 const source = {
     project: {
         versions,
-        currentVersion: versions[0].version
+        currentVersion: versions[0].version,
+        banner: {
+            visible: false,
+            content: 'Important <a href="#">security release</a>, please update now!'
+        }
     }
 };
-
 
 function buildlocale (locale) {
     console.time('[metalsmith] build/' + locale + ' finished');

--- a/layouts/css/page-modules/_home.styl
+++ b/layouts/css/page-modules/_home.styl
@@ -5,14 +5,6 @@
     text-align center
     margin-bottom 40px
 
-.home-download-banner
-    background-color #F7DF31
-    padding 5px
-    color #000
-
-    a
-        text-decoration underline
-
 .home-download
     background #eee
     display flex

--- a/layouts/index.hbs
+++ b/layouts/index.hbs
@@ -107,12 +107,19 @@
 
               {{{ contents }}}
 
-              <p class="version">Current Version: {{ project.currentVersion }}</p>
+              {{#if project.banner.visible}}
+                  <p class="version version-banner">
+                      Current Version: {{ project.currentVersion }}<br>
+                      {{{project.banner.content}}}
+                  </p>
+              {{else}}
+                  <p class="version">Current Version: {{ project.currentVersion }}</p>
+              {{/if}}
 
               <div class="buttons">
               <a href="https://nodejs.org/dist/{{ project.currentVersion }}/node-{{ project.currentVersion }}.pkg" class="button downloadbutton" id="downloadbutton">INSTALL</a>
 
-              <a href="download/" class="button" id="all-dl-options">Downloads</a><a href="api/" class="button" id="docsbutton">API Docs</a>
+              <a href="/{{site.locale}}/download/" class="button" id="all-dl-options">Downloads</a><a href="https://iojs.org/api/" class="button" id="docsbutton">API Docs</a>
               </div>
 
           </div>


### PR DESCRIPTION
closes #17 

Added a banner for security releases. You can hide it by changing the boolean in `build.js` and add a `url` for example for a blog post.

Also changed the two links at the bottom, so that they work.