### PR TITLE
style: fix styling of mobile header nav

### DIFF
--- a/layouts/css/layout/_lists.styl
+++ b/layouts/css/layout/_lists.styl
@@ -5,7 +5,12 @@
     li
         display inline-block
 
-        + li:before
-            content '|'
-            padding 0 .3em 0 .1em
-            color $lightgray
+@media screen and (min-width: 481px)
+  .list-divider-pipe
+
+      li
+
+          + li:before
+              content '|'
+              padding 0 .3em 0 .1em
+              color $lightgray

--- a/layouts/css/page-modules/_header.styl
+++ b/layouts/css/page-modules/_header.styl
@@ -7,31 +7,11 @@ header
         overflow visible
 
     li
-        $border-width = 14px
         position relative
-        padding-bottom 12px;
-
-        &.active:after
-            top 100%
-            left 50%
-            border solid rgba(0, 0, 0, 0)
-            content " "
-            height 0
-            width 0
-            position absolute
-            pointer-events none
-            border-color rgba(3, 3, 0, 0)
-            border-top-color $node-gray
-            border-width $border-width
-            margin-left -($border-width/2)px
-
-        &.active:first-child:after
-            margin-left -($border-width)px
 
     a,
     a:link,
     a:active
-        padding 0 8px
         text-transform uppercase
         font-size 14px
         // the header css apparently disobeys cascading rules, so, !important.
@@ -40,6 +20,47 @@ header
     a:hover
         background-color transparent
         text-decoration underline
+
+
+@media screen and (min-width: 481px)
+    header
+        li
+            $border-width = 14px
+            padding-bottom 12px;
+
+            &.active:after
+                top 100%
+                left 50%
+                border solid rgba(0, 0, 0, 0)
+                content " "
+                height 0
+                width 0
+                position absolute
+                pointer-events none
+                border-color rgba(3, 3, 0, 0)
+                border-top-color $node-gray
+                border-width $border-width
+                margin-left -($border-width/2)px
+
+            &.active:first-child:after
+                margin-left -($border-width)px
+
+        a,
+        a:link,
+        a:active
+            padding 0 8px
+
+@media screen and (max-width: 480px)
+    header
+        li
+            width 50%
+            float left
+            padding 0
+            margin 0
+        a,
+        a:link,
+        a:active
+            padding 0
 
 #logo
     width 182px


### PR DESCRIPTION
This changes the header nav to be 2 column rows on small screen devices.

It currently removes the dividers. Do we want to keep those in between?

Before:

![screen shot 2015-08-30 at 8 55 47 am](https://cloud.githubusercontent.com/assets/677994/9567579/632d1c18-4ef6-11e5-8b3f-6c2765a144d7.png)

After:

![screen shot 2015-08-30 at 8 55 30 am](https://cloud.githubusercontent.com/assets/677994/9567581/6b8961c8-4ef6-11e5-9336-198eb1ef0a99.png)
