### PR TITLE
fixed canonical URLs

### DIFF
--- a/layouts/partials/html-head.hbs
+++ b/layouts/partials/html-head.hbs
@@ -14,7 +14,7 @@
     {{!-- <link rel="apple-touch-icon" href="/static/apple-touch-icon.png"> --}}
     {{!-- <link rel="icon" href="/static/apple-touch-icon.png"> --}}
 
-    <link rel="canonical" href="{{ canonical }}">
+    <link rel="canonical" href="{{site.url}}{{path}}">
     <link rel="alternate" href="/{{site.locale}}/blog.xml" title="Node.js Blog" type="application/rss+xml">
     <link rel="alternate" href="/{{site.locale}}/tsc-minutes.xml" title="Node.js TSC meeting minutes" type="application/rss+xml">
     <link rel="stylesheet" href="/{{site.locale}}/styles.css" media="all">


### PR DESCRIPTION
Turns out the `{{canonical}}` field does not exist. Glued it together from two different fields.