### PR TITLE
fix windows binary download link

### DIFF
--- a/layouts/download.hbs
+++ b/layouts/download.hbs
@@ -49,8 +49,8 @@
 
                             <tr>
                                 <th>Windows Binary (.exe)</th>
-                                <td><a href="/dist/{{project.currentVersion}}/win-x86/iojs.exe">32-bit</a></td>
-                                <td><a href="/dist/{{project.currentVersion}}/win-x64/iojs.exe">64-bit</a></td>
+                                <td><a href="/dist/{{project.currentVersion}}/node.exe">32-bit</a></td>
+                                <td><a href="/dist/{{project.currentVersion}}/x64/node.exe">64-bit</a></td>
                             </tr>
 
                             <tr>


### PR DESCRIPTION
NOTE: from v4 onward we'll be using the win-x??/ directories but old
releases will use the old locations, so we'll have to either lean on
server rewrites or template logic to switch between v4 and v0 locations