### PR TITLE
css: Fix default background-color

### DIFF
--- a/layouts/css/base.styl
+++ b/layouts/css/base.styl
@@ -6,6 +6,7 @@ body
     font 300 20px/1.5 'Source Sans Pro', Arial, sans-serif
     color #333
     margin 0
+    background-color #fff
 
 header,
 main,


### PR DESCRIPTION
Without specifying this explicit color, the site is currently unreadable for people who have configured their browser to display white on black texts.