### PR TITLE
Fix lint script after moving files

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "gulp": "gulp",
     "build": "node build.js",
     "serve": "node build.js serve",
-    "lint": "eslint scripts build.js plugins",
+    "lint": "eslint scripts build.js",
     "load-versions": "node scripts/load-versions.js"
   },
   "repository": {


### PR DESCRIPTION
The contents of the previous `./plugins` directory got moved into `./scripts` in 7448a271 which resulted in breaking the `$ npm run lint` script.