### PR TITLE
Removes border around node.js logo in IE10

### DIFF
--- a/layouts/css/page-modules/_header.styl
+++ b/layouts/css/page-modules/_header.styl
@@ -74,3 +74,4 @@ header
         margin .5em auto 1em auto
         width 9em
         height auto
+        border none


### PR DESCRIPTION
While I was testing #96 I noticed a border around the logo in IE10.
This removes that border.