### PR TITLE
Updated readme new.nodejs.org -> nodejs.org and contributors

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,26 +1,24 @@
-# [new.nodejs.org](https://new.nodejs.org/)
+# [nodejs.org](https://nodejs.org/)
 [![Dependency Status](https://david-dm.org/nodejs/new.nodejs.org.svg)](https://david-dm.org/nodejs/new.nodejs.org)
 [![MIT Licensed](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 
 ## What is this repo?
 
-`new.nodejs.org` represents an effort by the newly formed [Node.js Foundation](https://nodejs.org/foundation/) to build on the merged community's past website projects to form a self-publishing, community-managed version of [nodejs.org](https://nodejs.org).
+`nodejs.org` represents an effort by the newly formed [Node.js Foundation](https://nodejs.org/foundation/) to build on the merged community's past website projects to form a self-publishing, community-managed version of the old [nodejs.org](https://nodejs.org).
 
-On a technical level inspiration will be taken from the `iojs.org` repo while design and content will be migrated from the existing `nodejs.org` repo. These technical changes will help to facilitate community involvement and empower the foundation's internationalization communities to provide alternative website content in other languages.
+On a technical level inspiration will be taken from the `iojs.org` repo while design and content will be migrated from the old `nodejs.org` repo. These technical changes will help to facilitate community involvement and empower the foundation's internationalization communities to provide alternative website content in other languages.
 
 This repo's issues section will also become the primary home for the Website WG's coordination efforts (meeting planning, minute approval, etc.)
 
-Targeted launch is late August / early September. [Tracked here](https://github.com/nodejs/build/issues/163).
-
 ## Contributing
 
-Please contribute! There's [plenty to do](https://github.com/nodejs/new.nodejs.org/issues/20).
+Please contribute! There's plenty to of [good first contributions](https://github.com/nodejs/new.nodejs.org/labels/good%20first%20contribution) to do.
 
-```
-git clone git@github.com:nodejs/new.nodejs.org.git
-cd new.nodejs.org
-npm install
-npm run serve
+```bash
+$ git clone git@github.com:nodejs/new.nodejs.org.git
+$ cd new.nodejs.org
+$ npm install
+$ npm run serve
 ```
 
 This will start the development server on http://localhost:8080/en/ and should reload automatically when you make changes but it's all just code and no code is perfect so sometimes you may need to restart it :)
@@ -38,7 +36,7 @@ Note: You'll need io.js 2.x or newer as the build system uses some native ES2015
  * All content is in Markdown and is per locale.
   * The top of each Markdown file is a block of YAML for page specific localization information that is passed to various templates.
   * The bulk of the Markdown content for each page is referenced as `{{{content}}}` in the corresponding template.
-  
+
 ## Governance and Current Members
 
 All of the Node.js Foundation websites, including this repo, are jointly governed by the **Website Working Group**. See [GOVERNANCE.md](./GOVERNANCE.md) to learn more about the group's structure and [CONTRIBUTING.md](./CONTRIBUTING.md) for guidance about the expectations for all contributors to this project.
@@ -55,4 +53,4 @@ All of the Node.js Foundation websites, including this repo, are jointly governe
 
 ### Website Project Contributors
 
-`...`
+- Phillip Johnsen: @phillipj, [@phillipjohnsen](https://twitter.com/phillipjohnsen), `johphi``@``gmail.com`


### PR DESCRIPTION
Removed mentions of new.nodejs.org, contribution tip and added myself to the contributors list. 

Any suggestions about the last bit of the repo description? Is the old nodejs.org still deployed somewhere or should we just remove the reference to it all together?

> `nodejs.org` represents an effort by the newly formed [Node.js Foundation](https://nodejs.org/foundation/) to build on the merged community's past website projects to form a self-publishing, community-managed version **of the old [nodejs.org](https://nodejs.org)**.