### PR TITLE
Prefer developers.google.com/v8/ for V8 link

### DIFF
--- a/locale/en/docs/es6.md
+++ b/locale/en/docs/es6.md
@@ -4,7 +4,7 @@ layout: docs.hbs
 ---
 # ES6 on Node.js
 
-Node.js is built against modern versions of [V8](https://code.google.com/p/v8/). By keeping up-to-date with the latest releases of this engine we ensure new features from the [JavaScript ECMA-262 specification](http://www.ecma-international.org/publications/standards/Ecma-262.htm) are brought to Node.js developers in a timely manner, as well as continued performance and stability improvements.
+Node.js is built against modern versions of [V8](https://developers.google.com/v8/). By keeping up-to-date with the latest releases of this engine we ensure new features from the [JavaScript ECMA-262 specification](http://www.ecma-international.org/publications/standards/Ecma-262.htm) are brought to Node.js developers in a timely manner, as well as continued performance and stability improvements.
 
 All ES6 features are split into three groups for **shipping**, **staged** and **in progress** features:
 

--- a/locale/en/index.md
+++ b/locale/en/index.md
@@ -9,7 +9,7 @@ labels:
   api: API Docs
 ---
 
-Node.js® is a JavaScript runtime built on [Chrome's V8 JavaScript engine](http://code.google.com/p/v8/).
+Node.js® is a JavaScript runtime built on [Chrome's V8 JavaScript engine](https://developers.google.com/v8/).
 Node.js uses an event-driven, non-blocking I/O model that makes it
 lightweight and efficient. Node.js' package ecosystem, [npm](https://www.npmjs.com/), is the largest ecosystem of open
 source libraries in the world.


### PR DESCRIPTION
The old code.google.com link is no longer the best link for more V8 information.  The developers.google.com link is the most up-to-date home for info.