### PR TITLE
Mobile tweaks

### DIFF
--- a/layouts/css/base.styl
+++ b/layouts/css/base.styl
@@ -75,6 +75,7 @@ pre
 @import 'page-modules/_blog-index'
 @import 'page-modules/_blog-post'
 @import 'page-modules/_foundation-members'
+@import 'page-modules/_in-the-news'
 @import 'page-modules/_download'
 @import 'page-modules/_scrollToTop'
 

--- a/layouts/css/page-modules/_foundation-members.styl
+++ b/layouts/css/page-modules/_foundation-members.styl
@@ -5,4 +5,4 @@ img.memberlogo
     width 200px
     padding-right 20px
     padding-left 20px
-    padding-bottom 5px
+    padding-bottom 20px

--- a/layouts/css/page-modules/_in-the-news.styl
+++ b/layouts/css/page-modules/_in-the-news.styl
@@ -1,0 +1,5 @@
+#news-container
+    margin-top 50px
+
+    .news-row
+        padding 5px

--- a/layouts/in-the-news.hbs
+++ b/layouts/in-the-news.hbs
@@ -30,14 +30,6 @@
 
             {{{ contents }}}
 
-            <style>
-            div#news-container {
-              margin-top:50px;
-            }
-            div.news-row: {
-              padding: 5px 5px 5px 5px;
-            }
-            </style>
             <article>
               <div id="news-container">
               </div>


### PR DESCRIPTION
Part of #57 

Move in-the-news styles into own stylesheet and remove bad `:` character so the padding is correctly applied
before:
![image](https://cloud.githubusercontent.com/assets/2513462/9744419/1179ec50-56af-11e5-883b-db78bfeacf6d.png)

after:
![image](https://cloud.githubusercontent.com/assets/2513462/9744439/229922da-56af-11e5-917a-549b64e2e787.png)

-----

increase spacing between foundation member logos
before:
![image](https://cloud.githubusercontent.com/assets/2513462/9744369/c62f7d8c-56ae-11e5-87ac-056759c321a0.png)

after:
![image](https://cloud.githubusercontent.com/assets/2513462/9744382/e2922592-56ae-11e5-9344-c3afad0f4582.png)

