### PR TITLE
Propper and more stick link to changelog

### DIFF
--- a/layouts/index.hbs
+++ b/layouts/index.hbs
@@ -25,7 +25,7 @@
 
                 <ul class="list-divider-pipe home-secondary-links">
                     <li><a href="https://nodejs.org/dist/latest/">{{ labels.other-downloads }}</a></li>
-                    <li><a href="https://github.com/nodejs/node/blob/master/CHANGELOG.md">{{ labels.changelog }}</a></li>
+                    <li><a href="https://github.com/nodejs/node/blob/{{ project.currentVersion }}/CHANGELOG.md">{{ labels.changelog }}</a></li>
                     <li><a href="{{ site.docs.api.link }}">{{ labels.api }}</a></li>
                 </ul>
 


### PR DESCRIPTION
Currently, the changelog link is pointing to the master version of the file, which shows [changes for io.js version 3.3.0](https://github.com/nodejs/node/blob/master/CHANGELOG.md).