### PR TITLE
css: banner text drop shadow (hard to read otherwise)

### DIFF
--- a/layouts/index.hbs
+++ b/layouts/index.hbs
@@ -48,6 +48,8 @@
                     vertical-align: center;
                     padding-top:80px;
                     height:140px;
+                    -webkit-filter: drop-shadow(5px 5px 5px #222);
+                    filter: drop-shadow(5px 5px 5px #222);
                 }
                 footer {
                     margin-top:0px;


### PR DESCRIPTION
I noticed that the white text on the Node.js Interactive banner is hard to read because of the background so added some shadows to the text. Hope you also find it useful.