### PR TITLE
change ES6 in progress example

### DIFF
--- a/locale/en/docs/es6.md
+++ b/locale/en/docs/es6.md
@@ -10,7 +10,7 @@ All ES6 features are split into three groups for **shipping**, **staged** and **
 
 * All **shipping** features, which V8 considers stable are turned **on by default on Node.js** and do **NOT** require any kind of runtime flag.
 * **Staged** features, which are almost-completed features that are not considered stable by the V8 team, require a runtime flag: `--es_staging` (or its synonym, `--harmony`).
-* **In progress** features can be activated individually by their respective harmony flag (e.g. `--harmony_modules`), although this is highly discouraged unless for testing purposes.
+* **In progress** features can be activated individually by their respective harmony flag (e.g. `--harmony_destructuring`), although this is highly discouraged unless for testing purposes.
 
 ## Which ES6 features ship with Node.js by default (no runtime flag required)?
 


### PR DESCRIPTION
People are trying to use the --harmony_modules flag and see that it does not work at all.
Suggest `--harmony_destructuring` instead. It is less buggy.
Ref: https://github.com/nodejs/node/issues/2760